### PR TITLE
Add remove format plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "@ckeditor/ckeditor5-media-embed": "^34.0.0",
         "@ckeditor/ckeditor5-paragraph": "^34.0.0",
         "@ckeditor/ckeditor5-paste-from-office": "^34.0.0",
+        "@ckeditor/ckeditor5-remove-format": "^34.0.0",
         "@ckeditor/ckeditor5-source-editing": "^34.0.0",
         "@ckeditor/ckeditor5-table": "^34.0.0",
         "@ckeditor/ckeditor5-theme-lark": "^34.0.0",

--- a/resources/js/ckeditor/ckeditor.js
+++ b/resources/js/ckeditor/ckeditor.js
@@ -22,6 +22,7 @@ import Font from '@ckeditor/ckeditor5-font/src/font'
 
 // Styles & Enhancements
 import PasteFromOffice from '@ckeditor/ckeditor5-paste-from-office/src/pastefromoffice'
+import RemoveFromat from '@ckeditor/ckeditor5-remove-format/src/removeformat'
 import StrikeThrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough'
 import Code from '@ckeditor/ckeditor5-basic-styles/src/code'
 import Superscript from '@ckeditor/ckeditor5-basic-styles/src/superscript'
@@ -103,6 +104,7 @@ export default class CkEditor extends ClassicEditorBase {
             Superscript,
             StrikeThrough,
             Code,
+            RemoveFromat,
             Image,
             ImageStyle,
             ImageUpload,


### PR DESCRIPTION
Hi,
CkEditor has a pretty good Paste from Office plugin compared to other rich text editors. However some unwanted styles remain (like negative margins).
To have a nice HTML, I created this PR to add remove format plugin so we can add the `removeFormat` button.

I couldn't test the code myself because of missing peer dependencies in package.json (`@ckeditor/ckeditor5-core`, `@ckeditor/ckeditor5-utils`, `ckeditor5`).

Thanks for you package,
Karel