### PR TITLE
feat: support ImageInsert

### DIFF
--- a/config/nova-ckeditor.php
+++ b/config/nova-ckeditor.php
@@ -476,6 +476,8 @@ return [
                         'resizeImage:50',
                         'resizeImage:75',
                         'resizeImage:original',
+                        '|',
+                        'insertImage',
                     ],
 
                     'styles' => [

--- a/resources/js/ckeditor/ckeditor.js
+++ b/resources/js/ckeditor/ckeditor.js
@@ -47,6 +47,7 @@ import MediaEmbed from '@ckeditor/ckeditor5-media-embed/src/mediaembed'
 import HtmlEmbed from '@ckeditor/ckeditor5-html-embed/src/htmlembed'
 import ImageTextAlternative from '@ckeditor/ckeditor5-image/src/imagetextalternative'
 import {LinkImage} from '@ckeditor/ckeditor5-link'
+import { ImageInsert } from '@ckeditor/ckeditor5-image'
 
 // Intend
 import Indent from '@ckeditor/ckeditor5-indent/src/indent';
@@ -127,6 +128,7 @@ export default class CkEditor extends ClassicEditorBase {
             ImageCaption,
             ImageResize,
             LinkImage,
+            ImageInsert,
             ImageToolbar,
             ImageTextAlternative,
             MediaEmbed,


### PR DESCRIPTION
It seems this feature which should be enabled in all predefined builds is missing from Nova CKEditor.

https://ckeditor.com/docs/ckeditor5/latest/features/images/images-inserting.html#inserting-images-via-a-source-url

The dropdown next to the 'insertImage' seems to be missing. I've checked the source files of this project, and no mention of the plugin 'ImageInsert ' being enabled.

![Screenshot 2024-05-01 at 22 14 51](https://github.com/mostafaznv/nova-ckeditor/assets/2600040/b786d1a5-4dc2-41d9-8a83-e8da06ee6b3e)
